### PR TITLE
add agent Role object

### DIFF
--- a/charts/parca/templates/agent-podsecuritypolicy.yaml
+++ b/charts/parca/templates/agent-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.enabled -}}
+{{- if and .Values.agent.enabled .Values.agent.podSecurityPolicy.enabled -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/parca/templates/agent-role.yaml
+++ b/charts/parca/templates/agent-role.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.enabled -}}
+{{- if and .Values.agent.enabled .Values.agent.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/parca/templates/agent-rolebinding.yaml
+++ b/charts/parca/templates/agent-rolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.enabled -}}
+{{- if and .Values.agent.enabled .Values.agent.podSecurityPolicy.enabled -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -54,6 +54,9 @@ agent:
       operator: Exists
   # -- resource limits and requests
   resources: {}
+  # -- podSecurityPolicy for agent
+  podSecurityPolicy:
+    enabled: true
 
 server:
   # -- Allows disabling parca server


### PR DESCRIPTION
I was investigating this helm chart from the security perspective and I noticed few things, one of which is lack of agent Role allowing agent to use PSP (included in this PR).

Additionally this helm chart looks like it is a bit more relaxed in terms of security when compared to jsonnet code in parca and parca-agent repositories. The jsonnet code has 2 main advantages:
- it ships PSP for parca server
- there is no sharing of SA between parca server and agent

I tried to include those things, but it turned out to be a task longer than anticipated. IMHO it would make sense to consider splitting `agent` and `server` into 2 helm charts and is necessary provide a 3rd helm chart joining both into one.

FWIW I combined pros of this helm chart (scrape configuration enabled by default) with jsonnet code and generated manifests are available at https://github.com/thaum-xyz/ankhmorpork/tree/master/apps/parca/manifests