### PR TITLE
Fix agent daemon set env

### DIFF
--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -51,16 +51,15 @@ spec:
             {{- if .Values.agent.podLabelSelector }}
             - --pod-label-selector={{ .Values.agent.podLabelSelector }}
             {{- end }}
-          env:
-          - name: NODE_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: spec.nodeName
           ports:
           - containerPort: 7071
             hostPort: 7071
             name: http
           env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             {{- with .Values.agent.extraEnv }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
This PR fixes the `env` parameter of the agent daemonset. Ran into an issue where the `NODE_NAME` was not populated because Kubernetes is not going to merge to the `env` defined in the manifest and will end up with an empty array.