### PR TITLE
#13 various fixes to helm chart

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.0
+version: 2.2.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -11,6 +11,7 @@ Open Source Infrastructure-wide continuous profiling
 ### Changes
 
 #### 2.0.0
+
 In chart version 2.0.0, following things has changed:
 
 * agent.socketPath is now unset by default. If you need custom path to CRI socket (ie for k3s it is /run/containerd/containerd.sock) you will need to specify it manually now.
@@ -22,11 +23,13 @@ Please consult [official docs](https://www.parca.dev/docs/overview) on usage.
 Chart includes prometheus-style discovery rule with annotations:
 
 If you want k8s prometheus-like scraping for pprof endpoints, all you need is to add annotations for pod:
+
 ```
 parca.dev/scrape: 'true'
 ```
 
 to furter adjust scope of scraping, you can use
+
 ```
 parca.dev/port: 'debug'
 ```
@@ -44,6 +47,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | agent.enabled | bool | `true` | Allows disabling parca agent |
+| agent.extraArgs | list | `[]` | additional arguments for agent |
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
@@ -75,6 +79,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.config | object | `{"debug_info":{"bucket":{"config":{"directory":"./tmp"},"type":"FILESYSTEM"},"cache":{"config":{"directory":"./tmp"},"type":"FILESYSTEM"}}}` | parca server config block |
 | server.corsAllowedOrigins | string | `"*"` | CORS setting |
 | server.enabled | bool | `true` | Allows disabling parca server |
+| server.extraArgs | list | `[]` | additional arguments for server |
 | server.extraEnv | list | `[]` | additional container environment variables for server |
 | server.image.pullPolicy | string | `"IfNotPresent"` | Overrides pull policy for server |
 | server.image.repository | string | `"ghcr.io/parca-dev/parca"` | Overrides the image repository for server |

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 2.1.0](https://img.shields.io/badge/Version-2.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.0](https://img.shields.io/badge/AppVersion-v0.12.0-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.12.1](https://img.shields.io/badge/AppVersion-v0.12.1-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 
@@ -11,7 +11,6 @@ Open Source Infrastructure-wide continuous profiling
 ### Changes
 
 #### 2.0.0
-
 In chart version 2.0.0, following things has changed:
 
 * agent.socketPath is now unset by default. If you need custom path to CRI socket (ie for k3s it is /run/containerd/containerd.sock) you will need to specify it manually now.
@@ -23,13 +22,11 @@ Please consult [official docs](https://www.parca.dev/docs/overview) on usage.
 Chart includes prometheus-style discovery rule with annotations:
 
 If you want k8s prometheus-like scraping for pprof endpoints, all you need is to add annotations for pod:
-
 ```
 parca.dev/scrape: 'true'
 ```
 
 to furter adjust scope of scraping, you can use
-
 ```
 parca.dev/port: 'debug'
 ```
@@ -47,11 +44,11 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | agent.enabled | bool | `true` | Allows disabling parca agent |
-| agent.extraArgs | list | `[]` | additional arguments for agent |
+| agent.extraArgs | list | `[]` | additional arguments to pass to the agent |
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
-| agent.image.tag | string | `"v0.9.0"` | Overrides the image tag |
+| agent.image.tag | string | `"v0.9.1"` | Overrides the image tag |
 | agent.logLevel | string | `"info"` | Agent log level |
 | agent.nodeSelector | object | `{}` | node selector for scheduling agent pods |
 | agent.podAnnotations | object | `{}` | Additional annotations for pods |
@@ -79,11 +76,11 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.config | object | `{"debug_info":{"bucket":{"config":{"directory":"./tmp"},"type":"FILESYSTEM"},"cache":{"config":{"directory":"./tmp"},"type":"FILESYSTEM"}}}` | parca server config block |
 | server.corsAllowedOrigins | string | `"*"` | CORS setting |
 | server.enabled | bool | `true` | Allows disabling parca server |
-| server.extraArgs | list | `[]` | additional arguments for server |
+| server.extraArgs | list | `[]` | additional arguments to pass to the server |
 | server.extraEnv | list | `[]` | additional container environment variables for server |
 | server.image.pullPolicy | string | `"IfNotPresent"` | Overrides pull policy for server |
 | server.image.repository | string | `"ghcr.io/parca-dev/parca"` | Overrides the image repository for server |
-| server.image.tag | string | `"v0.12.0"` | Overrides the image tag for server |
+| server.image.tag | string | `"v0.12.1"` | Overrides the image tag for server |
 | server.logLevel | string | `"info"` | logging level of parca server |
 | server.nodeSelector | object | `{}` | node selector for scheduling server pod |
 | server.otlpAddress | string | `""` | OpenTelemetry collector address to send traces to |

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -51,6 +51,9 @@ spec:
             {{- if .Values.agent.podLabelSelector }}
             - --pod-label-selector={{ .Values.agent.podLabelSelector }}
             {{- end }}
+            {{- with .Values.agent.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
           - containerPort: 7071
             hostPort: 7071

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -46,10 +46,13 @@ spec:
             {{- if .Values.server.otlpAddress }}
             - --otlp-address={{ .Values.server.otlpAddress }}
             {{- end }}
+            {{- with .Values.server.extraArgs }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           livenessProbe:
             exec:
               command:
-              - /grpc-health-probe
+              - /grpc_health_probe
               - -v
               - -addr=:7070
             initialDelaySeconds: 5
@@ -59,7 +62,7 @@ spec:
           readinessProbe:
             exec:
               command:
-              - /grpc-health-probe
+              - /grpc_health_probe
               - -v
               - -addr=:7070
             initialDelaySeconds: 10

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -21,6 +21,8 @@ agent:
   logLevel: info
   # -- label selector for filtering out pods with pprof, ie "parca=enabled"
   podLabelSelector: ""
+  # -- additional arguments to pass to the agent
+  extraArgs: []
   # -- Additional container environment variables for agent
   extraEnv: []
   # -- Address of parca server to send profiles. If not defined, will be generated based on deployment settings.
@@ -71,6 +73,8 @@ server:
   storageActiveMemory: 536870912
   # -- OpenTelemetry collector address to send traces to
   otlpAddress: ""
+  # -- additional arguments to pass to the server
+  extraArgs: []
   # -- additional container environment variables for server
   extraEnv: []
   # -- parca server config block


### PR DESCRIPTION
Update the grpc health check as it changed in 0.12.1, add the ability to set extraArg, and fix the env being overwritten as it was double declared.