### PR TITLE
Make PSP deployment optional

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.3.1
+version: 3.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -10,6 +10,12 @@ Open Source Infrastructure-wide continuous profiling
 
 ### Changes
 
+#### 3.0.0
+
+In chart version 3.0.0, the following has changed:
+
+* The PodSecurityPolicy for the agents is now disabled by default as PSPs are removed with Kubernetes 1.25. Use `agent.enablePsp: true` if you want to keep it.
+
 #### 2.3.1
 In the chart version 2.3.1, the following has changed:
 the _server.service.annotations_ is now available, so the parca server service manifest can have additional annotations.

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 2.3.1](https://img.shields.io/badge/Version-2.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
+![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.13.0](https://img.shields.io/badge/AppVersion-v0.13.0-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 
@@ -47,6 +47,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| agent.enablePsp | bool | `false` | If the PodSecurityPolicy should be enabled |
 | agent.enabled | bool | `true` | Allows disabling parca agent |
 | agent.extraArgs | list | `[]` | additional arguments to pass to the agent |
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |

--- a/charts/parca/README.md.gotmpl
+++ b/charts/parca/README.md.gotmpl
@@ -10,6 +10,12 @@
 
 ### Changes
 
+#### 3.0.0
+
+In chart version 3.0.0, the following has changed:
+
+* The PodSecurityPolicy for the agents is now disabled by default as PSPs are removed with Kubernetes 1.25. Use `agent.enablePsp: true` if you want to keep it.
+
 #### 2.3.1
 In the chart version 2.3.1, the following has changed:
 the _server.service.annotations_ is now available, so the parca server service manifest can have additional annotations.

--- a/charts/parca/templates/agent-podsecuritypolicy.yaml
+++ b/charts/parca/templates/agent-podsecuritypolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.enabled -}}
+{{- if and .Values.agent.enabled .Values.agent.enablePsp -}}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -8,6 +8,10 @@ fullnameOverride: ""
 agent:
   # -- Allows disabling parca agent
   enabled: true
+
+  # -- If the PodSecurityPolicy should be enabled
+  enablePsp: false
+
   image:
     # -- Overrides the image repository
     repository: ghcr.io/parca-dev/parca-agent


### PR DESCRIPTION
With Kubernetes 1.25, PodSecurityPolicies have been removed.

Ideally, this chart will be migrated to use the [Pod Security Admission controller](https://kubernetes.io/docs/concepts/security/pod-security-admission/), which is in Beta in 1.23 (the oldest supported Kubernetes version) and 1.24 and stable in 1.25. Therefore, it can be assumed that all supported setups of Kubernetes have Pod Security admission enabled by default.

As a first step, this PR makes the PSP deployment configurable to enable users to update their clusters to 1.25 (or deploy on 1.25 or newer).
