### PR TITLE
feat!: update flags for parca-agent 0.10.0

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.2.0
+version: 4.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 4.0.0](https://img.shields.io/badge/Version-4.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 
@@ -9,6 +9,14 @@ Open Source Infrastructure-wide continuous profiling
 * <https://github.com/parca-dev/helm-charts>
 
 ### Changes
+
+#### 4.0.0
+
+The chart now supports parca-agent 0.10.0. Older versions of parca-agent are no longer supported.
+
+* `agent.storeAddress` is renamed to `agent.remoteStoreAddress`.
+* `agent.socketPath` has been removed as it is no longer supported by parca-agent
+* `agent.podLabelSelector` has been removed as it is no longer supported by parca-agent
 
 #### 3.0.0
 
@@ -59,20 +67,18 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
-| agent.image.tag | string | `"v0.9.1"` | Overrides the image tag |
+| agent.image.tag | string | `"v0.10.0"` | Overrides the image tag |
 | agent.logLevel | string | `"info"` | Agent log level |
 | agent.nodeSelector | object | `{}` | node selector for scheduling agent pods |
 | agent.podAnnotations | object | `{}` | Additional annotations for pods |
-| agent.podLabelSelector | string | `""` | label selector for filtering out pods with pprof, ie "parca=enabled" |
 | agent.podSecurityContext | object | `{}` | Additional pod secutiry context |
+| agent.remoteStoreAddress | string | `""` | Address of parca server to send profiles. If not defined, will be generated based on deployment settings. |
 | agent.resources | object | `{}` | resource limits and requests |
 | agent.securityContext | object | `{"privileged":true,"readOnlyRootFilesystem":true}` | Security context, needs to be prilileged for ful functionality |
 | agent.service.port | int | `7071` | service port for agent |
 | agent.service.type | string | `"ClusterIP"` | service type for agent |
 | agent.serviceMonitor.enabled | bool | `false` | enables prometheus servicemonitor for agent |
 | agent.serviceMonitor.jobLabel | string | `"parca-agent"` |  |
-| agent.socketPath | string | `""` | Path to host docker/containerd/crio socket |
-| agent.storeAddress | string | `""` | Address of parca server to send profiles. If not defined, will be generated based on deployment settings. |
 | agent.tolerations | list | `[{"effect":"NoSchedule","operator":"Exists"},{"effect":"NoExecute","operator":"Exists"}]` | node tolerations for scheduling agent pods |
 | fullnameOverride | string | `""` | Overrides helm-generated chart fullname |
 | imagePullSecrets | list | `[]` | specifies pull secrets for image repository |

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -67,7 +67,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
-| agent.image.tag | string | `"v0.10.0"` | Overrides the image tag |
+| agent.image.tag | string | `"v0.10.1"` | Overrides the image tag |
 | agent.logLevel | string | `"info"` | Agent log level |
 | agent.nodeSelector | object | `{}` | node selector for scheduling agent pods |
 | agent.podAnnotations | object | `{}` | Additional annotations for pods |

--- a/charts/parca/README.md.gotmpl
+++ b/charts/parca/README.md.gotmpl
@@ -10,6 +10,14 @@
 
 ### Changes
 
+#### 4.0.0
+
+The chart now supports parca-agent 0.10.0. Older versions of parca-agent are no longer supported.
+
+* `agent.storeAddress` is renamed to `agent.remoteStoreAddress`.
+* `agent.socketPath` has been removed as it is no longer supported by parca-agent
+* `agent.podLabelSelector` has been removed as it is no longer supported by parca-agent
+
 #### 3.0.0
 
 In chart version 3.0.0, the following has changed:

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -36,21 +36,13 @@ spec:
             - /bin/parca-agent
             - --log-level={{ .Values.agent.logLevel }}
             - --node=$(NODE_NAME)
-            - --kubernetes
-            {{- if .Values.agent.storeAddress }}
-            - --store-address={{ .Values.agent.storeAddress }}
+            {{- if .Values.agent.remoteStoreAddress }}
+            - --remote-store-address={{ .Values.agent.remoteStoreAddress }}
             {{- else }}
-            - --store-address={{ include "parca.fullname" . }}-server.{{ .Release.Namespace }}.svc.cluster.local:7070
+            - --remote-store-address={{ include "parca.fullname" . }}-server.{{ .Release.Namespace }}.svc.cluster.local:7070
             {{- end }}
-            - --insecure
-            - --insecure-skip-verify
-            - --temp-dir=/tmp
-            {{- if .Values.agent.socketPath }}
-            - --socket-path={{ .Values.agent.socketPath }}
-            {{- end }}
-            {{- if .Values.agent.podLabelSelector }}
-            - --pod-label-selector={{ .Values.agent.podLabelSelector }}
-            {{- end }}
+            - --remote-store-insecure
+            - --remote-store-insecure-skip-verify
             {{- with .Values.agent.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -18,19 +18,15 @@ agent:
     # -- Overrides pullpolicy
     pullPolicy: IfNotPresent
     # -- Overrides the image tag
-    tag: "v0.9.1"
-  # -- Path to host docker/containerd/crio socket
-  socketPath: ""
+    tag: "v0.10.0"
   # -- Agent log level
   logLevel: info
-  # -- label selector for filtering out pods with pprof, ie "parca=enabled"
-  podLabelSelector: ""
   # -- additional arguments to pass to the agent
   extraArgs: []
   # -- Additional container environment variables for agent
   extraEnv: []
   # -- Address of parca server to send profiles. If not defined, will be generated based on deployment settings.
-  storeAddress: ""
+  remoteStoreAddress: ""
   # -- Additional annotations for pods
   podAnnotations: {}
   # -- Additional pod secutiry context

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -18,7 +18,7 @@ agent:
     # -- Overrides pullpolicy
     pullPolicy: IfNotPresent
     # -- Overrides the image tag
-    tag: "v0.10.0"
+    tag: "v0.10.1"
   # -- Agent log level
   logLevel: info
   # -- additional arguments to pass to the agent


### PR DESCRIPTION
This PR makes the chart compatible with parca-agent 0.10.0.

BREAKING CHANGE: This breaks compatibility with parca-agent < 0.10.0
