### PR TITLE
feat: restart server when ConfigMap changes

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.0
+version: 3.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 3.1.0](https://img.shields.io/badge/Version-3.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
+![Version: 3.2.0](https://img.shields.io/badge/Version-3.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.14.0](https://img.shields.io/badge/AppVersion-0.14.0-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -16,10 +16,11 @@ spec:
       {{- include "parca.selectorLabels.server" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.server.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
+        {{- with .Values.server.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       labels:
         {{- include "parca.selectorLabels.server" . | nindent 8 }}
     spec:


### PR DESCRIPTION
With this change, the server deployment pod annotations change when the server ConfigMap changes, leading to a new rollout of the server pods.

This does away with the need to manually `kubectl rollout restart deployment parca` and prevents waste of time debugging why configuration was not applied.
