### PR TITLE
test: add pre-commit hook for helm-docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/norwoodj/helm-docs
+    rev: v1.11.0
+    hooks:
+      - id: helm-docs
+        args:
+          - --chart-search-root=charts

--- a/README.md
+++ b/README.md
@@ -9,4 +9,7 @@ helm install my-parca parca/parca
 ```
 
 ### Contributing
-If you added, removed or adjusted helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/parca folder to re-generate README
+
+If you added, removed or adjusted helm values, please run [helm-docs](https://github.com/norwoodj/helm-docs) in charts/parca folder to re-generate the README.
+
+If you have pre-commit installed, you can run `pre-commit install` to automatically run helm-docs for every commit.

--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,6 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "pre-commit": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
With this change, users of pre-commit can register a pre-commit hook that automatically
runs helm-docs when a chart changes.

This saves contributors such as me from forgetting to run `helm-docs` every single time
they commit if they want to do so.
