### PR TITLE
feat: added StatefulSet setup

### DIFF
--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -74,7 +74,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | agent.podSecurityContext | object | `{}` | Additional pod secutiry context |
 | agent.remoteStoreAddress | string | `""` | Address of parca server to send profiles. If not defined, will be generated based on deployment settings. |
 | agent.resources | object | `{}` | resource limits and requests |
-| agent.securityContext | object | `{"privileged":true,"readOnlyRootFilesystem":true}` | Security context, needs to be prilileged for ful functionality |
+| agent.securityContext | object | `{"privileged":true,"readOnlyRootFilesystem":true}` | Security context, needs to be prilileged for full functionality |
 | agent.service.port | int | `7071` | service port for agent |
 | agent.service.type | string | `"ClusterIP"` | service type for agent |
 | agent.serviceMonitor.enabled | bool | `false` | enables prometheus servicemonitor for agent |
@@ -101,8 +101,12 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.logLevel | string | `"info"` | logging level of parca server |
 | server.nodeSelector | object | `{}` | node selector for scheduling server pod |
 | server.otlpAddress | string | `""` | OpenTelemetry collector address to send traces to |
+| server.persistence.enabled | bool | `false` | turn on persistent storage for the metastore and profile storage. A StefulSet will be used |
+| server.persistence.existingClaim | string | `""` | use a existing PVC which must be created manually before bound |
+| server.persistence.size | string | `"8Gi"` | PVC size |
+| server.persistence.storageClassName | string | `""` | storage class |
 | server.podAnnotations | object | `{}` | additional annotations for server pod |
-| server.podSecurityContext | object | `{}` | additional security context for server pod |
+| server.podSecurityContext | object | `{"fsGroup":65534,"fsGroupChangePolicy":"OnRootMismatch"}` | additional security context for server pod |
 | server.resources | object | `{}` | resource limits and requests for server pod |
 | server.scrapeConfigs | list | `[{"job_name":"kubernetes-pods","kubernetes_sd_configs":[{"role":"pod"}],"relabel_configs":[{"action":"keep","regex":true,"source_labels":["__meta_kubernetes_pod_annotation_parca_dev_scrape"]},{"action":"replace","regex":"(.+)","source_labels":["__meta_kubernetes_pod_annotation_parca_dev_path"],"target_label":"__metrics_path__"},{"action":"replace","regex":"([^:]+)(?::\\d+)?;(\\d+)","replacement":"$1:$2","source_labels":["__address__","__meta_kubernetes_pod_annotation_parca_dev_port"],"target_label":"__address__"},{"action":"labelmap","regex":"__meta_kubernetes_pod_label_(.+)"},{"action":"replace","source_labels":["__meta_kubernetes_namespace"],"target_label":"kubernetes_namespace"},{"action":"replace","source_labels":["__meta_kubernetes_pod_name"],"target_label":"kubernetes_pod_name"}],"scrape_interval":"1m","scrape_timeout":"10s"}]` | scrape configs for parca server |
 | server.securityContext | object | `{}` | additional security context for server |

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -90,7 +90,12 @@ spec:
       {{- if .Values.server.persistence.enabled }}
       - name: data
         mountPath: /data
+        {{- if .Values.server.persistence.existingClaim }}
+        persistentVolumeClaim:
+          claimName: {{ printf "%s" (tpl .Values.server.persistence.existingClaim .) }}
+        {{- else }}
         emptyDir: {}
+        {{- end }}
       {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.server.enabled -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: {{ ternary "StatefulSet" "Deployment" .Values.server.persistence.enabled }}
 metadata:
   name: {{ include "parca.fullname" . }}
   labels:
@@ -14,6 +14,9 @@ spec:
   selector:
     matchLabels:
       {{- include "parca.selectorLabels.server" . | nindent 6 }}
+  {{- if .Values.server.persistence.enabled }}
+  serviceName: {{ include "parca.fullname" . }}-server
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -115,6 +115,9 @@ spec:
         labels:
           {{- include "parca.labels.server" . | nindent 10 }}
       spec:
+        {{- if .Values.server.persistence.storageClassName }}
+        storageClassName: {{ .Values.server.persistence.storageClassName }}
+        {{- end }}
         accessModes:
           - "ReadWriteOnce"
         resources:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -47,6 +47,9 @@ spec:
             {{- if .Values.server.otlpAddress }}
             - --otlp-address={{ .Values.server.otlpAddress }}
             {{- end }}
+            {{- if .Values.server.persistence.enabled }}
+            - --enable-persistence
+            {{- end }}
             {{- with .Values.server.extraArgs }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -87,15 +87,10 @@ spec:
       - configMap:
           name: {{ include "parca.fullname" . }}-server-config
         name: {{ include "parca.fullname" . }}-server-config
-      {{- if .Values.server.persistence.enabled }}
+      {{- if and .Values.server.persistence.enabled .Values.server.persistence.existingClaim }}
       - name: data
-        mountPath: /data
-        {{- if .Values.server.persistence.existingClaim }}
         persistentVolumeClaim:
           claimName: {{ printf "%s" (tpl .Values.server.persistence.existingClaim .) }}
-        {{- else }}
-        emptyDir: {}
-        {{- end }}
       {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
@@ -109,4 +104,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+  {{- if and .Values.server.persistence.enabled (not .Values.server.persistence.existingClaim) }}
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+        labels:
+          {{- include "parca.labels.server" . | nindent 10 }}
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: {{ .Values.server.persistence.size | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -81,6 +81,10 @@ spec:
           volumeMounts:
           - mountPath: /var/parca
             name: {{ include "parca.fullname" . }}-server-config
+          {{- if .Values.server.persistence.enabled }}
+          - mountPath: /data
+            name: data
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
       volumes:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -49,6 +49,7 @@ spec:
             {{- end }}
             {{- if .Values.server.persistence.enabled }}
             - --enable-persistence
+            - --storage-path=/data
             {{- end }}
             {{- with .Values.server.extraArgs }}
               {{- toYaml . | nindent 12 }}
@@ -83,6 +84,11 @@ spec:
       - configMap:
           name: {{ include "parca.fullname" . }}-server-config
         name: {{ include "parca.fullname" . }}-server-config
+      {{- if .Values.server.persistence.enabled }}
+      - name: data
+        mountPath: /data
+        emptyDir: {}
+      {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -144,6 +144,9 @@ server:
     existingClaim: ""
     # -- PVC size
     size: 8Gi
+    # -- storage class
+    storageClassName: ""
+
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -136,7 +136,7 @@ server:
   # -- resource limits and requests for server pod
   resources: {}
   persistence:
-    # -- turn on persistent storage for the metastore and profile storage.
+    # -- turn on persistent storage for the metastore and profile storage. A StefulSet will be used
     enabled: false
 
 serviceAccount:

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -115,7 +115,9 @@ server:
   # -- additional annotations for server pod
   podAnnotations: {}
   # -- additional security context for server pod
-  podSecurityContext: {}
+  podSecurityContext:
+    fsGroup: 65534
+    fsGroupChangePolicy: "OnRootMismatch"
   # -- additional security context for server
   securityContext: {}
   service:

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -135,6 +135,9 @@ server:
   tolerations: {}
   # -- resource limits and requests for server pod
   resources: {}
+  persistence:
+    # -- turn on persistent storage for the metastore and profile storage.
+    enabled: false
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -31,7 +31,7 @@ agent:
   podAnnotations: {}
   # -- Additional pod secutiry context
   podSecurityContext: {}
-  # -- Security context, needs to be prilileged for ful functionality
+  # -- Security context, needs to be prilileged for full functionality
   securityContext:
     privileged: true
     readOnlyRootFilesystem: true

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -140,6 +140,8 @@ server:
     enabled: false
     # -- use a existing PVC which must be created manually before bound
     existingClaim: ""
+    # -- PVC size
+    size: 8Gi
 
 serviceAccount:
   # -- Specifies whether a service account should be created

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -138,6 +138,8 @@ server:
   persistence:
     # -- turn on persistent storage for the metastore and profile storage. A StefulSet will be used
     enabled: false
+    # -- use a existing PVC which must be created manually before bound
+    existingClaim: ""
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
Added basic setup to use persistence with a PVC and a StatefulSet. Other charts (e.g. [Promethues](https://github.com/prometheus-community/helm-charts/tree/f4957381b36c4b6e3e5e69a5bb320f2ebb4baf01/charts/prometheus)) allow more options such as:
- using a non-persistent volume
- use PVCs with deployments

Here I made it to use either no persistence (current setup) or a StatefulSet with PVC