### PR TITLE
Extend and template RBAC cluster role

### DIFF
--- a/charts/parca/templates/clusterrole.yaml
+++ b/charts/parca/templates/clusterrole.yaml
@@ -10,14 +10,8 @@ rules:
 - apiGroups: [""]
   resources:
   - nodes
-  - nodes/metrics
   - services
   - endpoints
   - pods
-  verbs: ["get", "list", "watch"]
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - ingresses
   verbs: ["get", "list", "watch"]
 {{- end }}

--- a/charts/parca/templates/clusterrole.yaml
+++ b/charts/parca/templates/clusterrole.yaml
@@ -1,20 +1,23 @@
+{{- if and .Values.server.enabled .Values.server.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    {{- include "parca.labels" . | nindent 4 }}
   name: {{ include "parca.serviceAccountName" . }}
+  labels:
+    app: {{ include "parca.serviceAccountName" . }}
+{{- include "parca.labels" . | nindent 4 }}
 rules:
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  verbs:
-  - list
-  - watch
-- apiGroups:
-  - ""
+- apiGroups: [""]
   resources:
   - nodes
-  verbs:
-  - get
+  - nodes/metrics
+  - services
+  - endpoints
+  - pods
+  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - "networking.k8s.io"
+  resources:
+  - ingresses
+  verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -135,6 +135,9 @@ server:
   tolerations: {}
   # -- resource limits and requests for server pod
   resources: {}
+  # -- clusterrole and binding for kubernetes service discovery mechanism
+  rbac:
+    create: true
 
 serviceAccount:
   # -- Specifies whether a service account should be created


### PR DESCRIPTION
Add roles for Parca Server clusterrole to enable additional selectors as per:  [Prometheus k8s docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#kubernetes_sd_config)
Clusterrole now includes:
``` 
resources:
  - nodes
  - services
  - endpoints
  - pods