### PR TITLE
Feature/add extra labels

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -21,10 +21,10 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.5.0
+version: 4.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v0.16.0
+appVersion: v0.16.2

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 4.5.0](https://img.shields.io/badge/Version-4.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.0](https://img.shields.io/badge/AppVersion-v0.16.0-informational?style=flat-square)
+![Version: 4.6.0](https://img.shields.io/badge/Version-4.6.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.2](https://img.shields.io/badge/AppVersion-v0.16.2-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -66,12 +66,14 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | agent.enabled | bool | `true` | Allows disabling parca agent |
 | agent.extraArgs | list | `[]` | additional arguments to pass to the agent |
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
+| agent.extraLabels | object | `{}` | Additional labels for agent daemonset |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
 | agent.image.tag | string | `"v0.13.0"` | Overrides the image tag |
 | agent.logLevel | string | `"info"` | Agent log level |
 | agent.nodeSelector | object | `{}` | node selector for scheduling agent pods |
 | agent.podAnnotations | object | `{}` | Additional annotations for pods |
+| agent.podExtraLabels | object | `{}` | Additional labels for pods |
 | agent.podSecurityContext | object | `{}` | Additional pod secutiry context |
 | agent.remoteStoreAddress | string | `""` | Address of parca server to send profiles. If not defined, will be generated based on deployment settings. |
 | agent.remoteStoreBearerToken | string | `""` |  |
@@ -99,6 +101,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.enabled | bool | `true` | Allows disabling parca server |
 | server.extraArgs | list | `[]` | additional arguments to pass to the server |
 | server.extraEnv | list | `[]` | additional container environment variables for server |
+| server.extraLabels | object | `{}` | additional labels for deployment |
 | server.image.pullPolicy | string | `"IfNotPresent"` | Overrides pull policy for server |
 | server.image.repository | string | `"ghcr.io/parca-dev/parca"` | Overrides the image repository for server |
 | server.image.tag | string | `"v0.16.0"` | Overrides the image tag for server |
@@ -106,6 +109,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.nodeSelector | object | `{}` | node selector for scheduling server pod |
 | server.otlpAddress | string | `""` | OpenTelemetry collector address to send traces to |
 | server.podAnnotations | object | `{}` | additional annotations for server pod |
+| server.podExtraLabels | object | `{}` | additional labels for server pod |
 | server.podSecurityContext | object | `{}` | additional security context for server pod |
 | server.rbac | object | `{"create":true}` | clusterrole and binding for kubernetes service discovery mechanism |
 | server.resources | object | `{}` | resource limits and requests for server pod |

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "parca.fullname" . }}-agent
   labels:
     {{- include "parca.labels.agent" . | nindent 4 }}
+    {{- if .Values.agent.extraLabels }}
+    {{- with .Values.agent.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -18,11 +23,6 @@ spec:
       labels:
         parca: {{ include "parca.fullname" . }}-agent
         {{- include "parca.selectorLabels.agent" . | nindent 8 }}
-        {{- if .Values.agent.extraLabels }}
-        {{- with .Values.agent.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -18,6 +18,11 @@ spec:
       labels:
         parca: {{ include "parca.fullname" . }}-agent
         {{- include "parca.selectorLabels.agent" . | nindent 8 }}
+        {{- if .Values.agent.extraLabels }}
+        {{- with .Values.agent.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -23,6 +23,11 @@ spec:
       labels:
         parca: {{ include "parca.fullname" . }}-agent
         {{- include "parca.selectorLabels.agent" . | nindent 8 }}
+        {{- if .Values.agent.podExtraLabels }}
+        {{- with .Values.agent.podExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -32,6 +32,11 @@ spec:
       {{- end }}
       labels:
         {{- include "parca.selectorLabels.server" . | nindent 8 }}
+        {{- if .Values.server.podExtraLabels }}
+        {{- with .Values.server.podExtraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -27,6 +27,11 @@ spec:
       {{- end }}
       labels:
         {{- include "parca.selectorLabels.server" . | nindent 8 }}
+        {{- if .Values.server.extraLabels }}
+        {{- with .Values.server.extraLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "parca.fullname" . }}
   labels:
     {{- include "parca.labels.server" . | nindent 4 }}
+    {{- if .Values.server.extraLabels }}
+    {{- with .Values.server.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- end }}
 spec:
 {{- /*
   {{- if not .Values.autoscaling.enabled }}
@@ -27,11 +32,6 @@ spec:
       {{- end }}
       labels:
         {{- include "parca.selectorLabels.server" . | nindent 8 }}
-        {{- if .Values.server.extraLabels }}
-        {{- with .Values.server.extraLabels }}
-        {{- toYaml . | nindent 8 }}
-        {{- end }}
-        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -29,11 +29,15 @@ agent:
   extraArgs: []
   # -- Additional container environment variables for agent
   extraEnv: []
+  # -- Additional labels for agent daemonset
+  extraLabels: {}
   # -- Address of parca server to send profiles. If not defined, will be generated based on deployment settings.
   remoteStoreAddress: ""
   remoteStoreInsecure: true
   remoteStoreInsecureSkipVerify: true
   remoteStoreBearerToken: ""
+  # -- Additional labels for pods
+  podExtraLabels: {}
   # -- Additional annotations for pods
   podAnnotations: {}
   # -- Additional pod secutiry context
@@ -84,6 +88,8 @@ server:
   extraArgs: []
   # -- additional container environment variables for server
   extraEnv: []
+  # -- additional labels for deployment
+  extraLabels: {}
   # -- restart the server pod when `server.config` or `server.scrapeConfigs` changes. If this is `false`, the parca server
   # will reload the config once the mounted ConfigMap is updated, which has a delay that depends on your cluster configuration.
   restartOnConfigChange: true
@@ -121,6 +127,8 @@ server:
         - source_labels: [__meta_kubernetes_pod_name]
           action: replace
           target_label: kubernetes_pod_name
+  # -- additional labels for server pod
+  podExtraLabels: {}
   # -- additional annotations for server pod
   podAnnotations: {}
   # -- additional security context for server pod


### PR DESCRIPTION
Adding the option to add extra labels to both deployment/daemonset as well as pods.

The extra labels are useful for example to authenticate using aadpodidentity in azure, or extra cases that custom labels are required.