### PR TITLE
feat: add persistent storage claim

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -20,8 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-
-version: 4.8.0
+version: 5.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 4.8.0](https://img.shields.io/badge/Version-4.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.2](https://img.shields.io/badge/AppVersion-v0.16.2-informational?style=flat-square)
+![Version: 5.0.0](https://img.shields.io/badge/Version-5.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.16.2](https://img.shields.io/badge/AppVersion-v0.16.2-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 
@@ -96,7 +96,7 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | ingress.hosts[0].paths[0].pathType | string | `"ImplementationSpecific"` |  |
 | ingress.tls | list | `[]` |  |
 | nameOverride | string | `""` | overrides chart name |
-| server.config | object | `{"object_storage":{"bucket":{"config":{"directory":"./tmp"},"type":"FILESYSTEM"}}}` | parca server config block |
+| server.config | object | `{"object_storage":{"bucket":{"config":{"directory":"/storage"},"type":"FILESYSTEM"}}}` | parca server config block |
 | server.corsAllowedOrigins | string | `"*"` | CORS setting |
 | server.enabled | bool | `true` | Allows disabling parca server |
 | server.extraArgs | list | `[]` | additional arguments to pass to the server |
@@ -108,6 +108,12 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.logLevel | string | `"info"` | logging level of parca server |
 | server.nodeSelector | object | `{}` | node selector for scheduling server pod |
 | server.otlpAddress | string | `""` | OpenTelemetry collector address to send traces to |
+| server.persistence | object | `{"accessModes":["ReadWriteOnce"],"capacity":"10Gi","enabled":false,"mountPath":"/storage","storageClassName":""}` | persistence for the data |
+| server.persistence.accessModes | list | `["ReadWriteOnce"]` | Modes in which the volume can be accessed: |
+| server.persistence.capacity | string | `"10Gi"` | Amount of storage to request |
+| server.persistence.enabled | bool | `false` | If persistent storage should be enabled |
+| server.persistence.mountPath | string | `"/storage"` | Where the volume is mounted. Ensure that this is identical to server.config.object_storage.bucket.config.directory |
+| server.persistence.storageClassName | string | `""` | Name of the storage class |
 | server.podAnnotations | object | `{}` | additional annotations for server pod |
 | server.podExtraLabels | object | `{}` | additional labels for server pod |
 | server.podSecurityContext | object | `{}` | additional security context for server pod |

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -16,6 +16,14 @@ spec:
   replicas: {{ .Values.replicaCount }}
   {{- end }}
 */}}
+  {{- if .Values.server.persistence.enabled }}
+  {{- if (gt (.Values.server.replicaCount | int) 1) }}
+  {{- fail "You can currently only enable persistence for 1 replica since we use a Deployment + PVC." }}
+  {{- end }}
+  {{- /* Recreate is needed since parca uses directory locking for the metastore */}}
+  strategy:
+    type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "parca.selectorLabels.server" . | nindent 6 }}
@@ -88,12 +96,21 @@ spec:
           volumeMounts:
           - mountPath: /var/parca
             name: {{ include "parca.fullname" . }}-server-config
+          {{- if .Values.server.persistence }}
+          - mountPath: {{ .Values.server.persistence.mountPath }}
+            name: storage
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
       volumes:
       - configMap:
           name: {{ include "parca.fullname" . }}-server-config
         name: {{ include "parca.fullname" . }}-server-config
+      {{- if .Values.server.persistence }}
+      - name: storage
+        persistentVolumeClaim:
+          claimName: {{ include "parca.fullname" . }}
+      {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/parca/templates/server-pvc.yaml
+++ b/charts/parca/templates/server-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.server.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "parca.fullname" . }}
+spec:
+  {{- if .Values.server.persistence.storageClassName }}
+  storageClassName: "{{ .Values.server.persistence.storageClassName }}"
+  {{- end }}
+  resources:
+    requests:
+      storage: "{{ .Values.server.persistence.capacity }}"
+  accessModes: {{ toYaml .Values.server.persistence.accessModes | nindent 4}}
+{{- end }}

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -93,13 +93,29 @@ server:
   # -- restart the server pod when `server.config` or `server.scrapeConfigs` changes. If this is `false`, the parca server
   # will reload the config once the mounted ConfigMap is updated, which has a delay that depends on your cluster configuration.
   restartOnConfigChange: true
+
+  # -- persistence for the data
+  persistence:
+    # -- If persistent storage should be enabled
+    enabled: false
+    # -- Amount of storage to request
+    capacity: 10Gi
+    # -- Name of the storage class
+    storageClassName: ""
+    # -- Where the volume is mounted. Ensure that this is identical to server.config.object_storage.bucket.config.directory
+    mountPath: "/storage"
+    # -- Modes in which the volume can be accessed:
+    accessModes:
+      - ReadWriteOnce
+
   # -- parca server config block
   config:
     object_storage:
       bucket:
         type: "FILESYSTEM"
         config:
-          directory: "./tmp"
+          directory: "/storage"
+
   # -- scrape configs for parca server
   scrapeConfigs:
     - job_name: 'kubernetes-pods'


### PR DESCRIPTION
To persist data, this adds a persistent storage claim.

BREAKING CHANGES: The default storage path is now "/storage" to make
the configuration to use a PVC easier.

This requires action only if you have not explicitly set the storage path
AND if you require the storage to be at "/tmp".
