### PR TITLE
Added support for setting extra volumes

### DIFF
--- a/charts/parca/Chart.yaml
+++ b/charts/parca/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 4.15.0
+version: 4.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -1,6 +1,6 @@
 # parca
 
-![Version: 4.15.0](https://img.shields.io/badge/Version-4.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
+![Version: 4.16.0](https://img.shields.io/badge/Version-4.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.19.0](https://img.shields.io/badge/AppVersion-v0.19.0-informational?style=flat-square)
 
 Open Source Infrastructure-wide continuous profiling
 

--- a/charts/parca/README.md
+++ b/charts/parca/README.md
@@ -67,6 +67,8 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | agent.extraArgs | list | `[]` | additional arguments to pass to the agent |
 | agent.extraEnv | list | `[]` | Additional container environment variables for agent |
 | agent.extraLabels | object | `{}` | Additional labels for agent daemonset |
+| agent.extraVolumeMounts | list | `[]` | Additional volumeMounts for agent daemonset |
+| agent.extraVolumes | list | `[]` | Additional volumes for agent daemonset |
 | agent.image.pullPolicy | string | `"IfNotPresent"` | Overrides pullpolicy |
 | agent.image.repository | string | `"ghcr.io/parca-dev/parca-agent"` | Overrides the image repository |
 | agent.image.tag | string | `"v0.25.0"` | Overrides the image tag |
@@ -102,6 +104,8 @@ helm repo add parca https://parca-dev.github.io/helm-charts
 | server.extraArgs | list | `[]` | additional arguments to pass to the server |
 | server.extraEnv | list | `[]` | additional container environment variables for server |
 | server.extraLabels | object | `{}` | additional labels for deployment |
+| server.extraVolumeMounts | list | `[]` | Additional volumeMounts for server deployment |
+| server.extraVolumes | list | `[]` | Additional volumes for server deployment |
 | server.image.pullPolicy | string | `"IfNotPresent"` | Overrides pull policy for server |
 | server.image.repository | string | `"ghcr.io/parca-dev/parca"` | Overrides the image repository for server |
 | server.image.tag | string | `"v0.19.0"` | Overrides the image tag for server |

--- a/charts/parca/templates/agent-daemonset.yaml
+++ b/charts/parca/templates/agent-daemonset.yaml
@@ -100,6 +100,9 @@ spec:
           - mountPath: /var/parca-agent-remote-store-bearer-token
             name: parca-agent-remote-store-bearer-token
           {{- end }}
+          {{- with .Values.agent.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.agent.resources | nindent 12 }}
       hostPID: true
@@ -128,6 +131,9 @@ spec:
       - name: parca-agent-remote-store-bearer-token
         secret:
           secretName: parca-agent-remote-store-bearer-token
+      {{- end }}
+      {{- with .Values.agent.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
       {{- end }}
       {{- with .Values.agent.tolerations }}
       tolerations:

--- a/charts/parca/templates/server-deployment.yaml
+++ b/charts/parca/templates/server-deployment.yaml
@@ -88,12 +88,18 @@ spec:
           volumeMounts:
           - mountPath: /var/parca
             name: {{ include "parca.fullname" . }}-server-config
+          {{- with .Values.server.extraVolumeMounts }}
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.server.resources | nindent 12 }}
       volumes:
       - configMap:
           name: {{ include "parca.fullname" . }}-server-config
         name: {{ include "parca.fullname" . }}-server-config
+      {{- with .Values.server.extraVolumes }}
+        {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- with .Values.server.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/parca/values.yaml
+++ b/charts/parca/values.yaml
@@ -31,6 +31,10 @@ agent:
   extraEnv: []
   # -- Additional labels for agent daemonset
   extraLabels: {}
+  # -- Additional volumeMounts for agent daemonset
+  extraVolumeMounts: []
+  # -- Additional volumes for agent daemonset
+  extraVolumes: []
   # -- Address of parca server to send profiles. If not defined, will be generated based on deployment settings.
   remoteStoreAddress: ""
   remoteStoreInsecure: true
@@ -92,6 +96,10 @@ server:
   extraEnv: []
   # -- additional labels for deployment
   extraLabels: {}
+  # -- Additional volumeMounts for server deployment
+  extraVolumeMounts: []
+  # -- Additional volumes for server deployment
+  extraVolumes: []
   # -- restart the server pod when `server.config` or `server.scrapeConfigs` changes. If this is `false`, the parca server
   # will reload the config once the mounted ConfigMap is updated, which has a delay that depends on your cluster configuration.
   restartOnConfigChange: true


### PR DESCRIPTION
On our servers, Parca did not find the kernel config. We have it available in the `/boot` directory, but this was not mounted. To get this mounted, I had to fork the repo to add this.

With this, users can add other special mounts to the deployment if they need to.

Such as, to solve my issue, I would do:

```yaml
# values.yaml

agent:
  extraVolumeMounts:
    - mountPath: /boot
      name: boot
      readOnly: true
  extraVolumes:
    - hostPath:
        path: /boot
      name: boot
```

And then I get the correct volumes added.
